### PR TITLE
Fix Height/Diameter filter bugs and search_help enum truncation (v0.4.6)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pcbparts-mcp"
-version = "0.5.0"
+version = "0.5.1"
 description = "MCP server for searching electronic components for PCB design and assembly"
 requires-python = ">=3.12"
 # Dependencies are pinned to exact versions so a rebuild never silently pulls a new major/minor

--- a/src/pcbparts_mcp/alternatives.py
+++ b/src/pcbparts_mcp/alternatives.py
@@ -171,6 +171,12 @@ SPEC_PARSERS: dict[str, Callable[[str], float | None] | str | None] = {
     "Output Power": parse_power,
 }
 
+
+# Dimension spec fields that can fall back to the package string when the spec value is null.
+DIMENSION_SPEC_FIELDS: frozenset[str] = frozenset({
+    "Height - Seated (Max)", "Height", "Diameter",
+})
+
 # Specs that use exact string matching (case-insensitive)
 STRING_MATCH_SPECS = {
     "Temperature Coefficient",

--- a/src/pcbparts_mcp/alternatives.py
+++ b/src/pcbparts_mcp/alternatives.py
@@ -23,6 +23,7 @@ from pcbparts_mcp.parsers import (
     parse_frequency,
     parse_decibels,
     parse_impedance_at_freq,
+    parse_length_mm,
     impedance_at_freq_match,
 )
 
@@ -107,6 +108,10 @@ SPEC_PARSERS: dict[str, Callable[[str], float | None] | str | None] = {
     "Inductance": parse_inductance,
     # Frequency
     "Frequency": parse_frequency,
+    # Physical dimensions (aluminum electrolytics, discrete caps, etc.)
+    "Height - Seated (Max)": parse_length_mm,
+    "Height": parse_length_mm,
+    "Diameter": parse_length_mm,
     # Special handling
     "Impedance @ Frequency": "special",  # Uses impedance_at_freq_match()
     # String-match specs (no parser - use exact match)

--- a/src/pcbparts_mcp/db/attributes.py
+++ b/src/pcbparts_mcp/db/attributes.py
@@ -14,6 +14,8 @@ from ..subcategory_aliases import (
 
 logger = logging.getLogger(__name__)
 
+_VALUE_LIMIT = 50
+
 
 def list_attributes(
     conn: sqlite3.Connection,
@@ -118,22 +120,32 @@ def list_attributes(
             if any(fn in SPEC_PARSERS for fn in ATTRIBUTE_ALIASES.get(alias_lookup.get(name, ""), [name]))
         )
 
-        # Simpler check: see if any value parses as numeric
         values = list(attr_values.get(name, []))
         parser = SPEC_PARSERS.get(name)
-        if not parser:
-            # Check aliases
+        if not callable(parser):
+            parser = None
+        if parser is None:
             alias = alias_lookup.get(name)
             if alias and alias in ATTRIBUTE_ALIASES:
                 for alias_target in ATTRIBUTE_ALIASES[alias]:
-                    if alias_target in SPEC_PARSERS:
-                        parser = SPEC_PARSERS[alias_target]
+                    candidate = SPEC_PARSERS.get(alias_target)
+                    if callable(candidate):
+                        parser = candidate
                         break
 
-        # Test if values are numeric
-        if parser and values:
-            numeric_count = sum(1 for v in values[:10] if parser(v) is not None)
-            is_numeric = numeric_count >= len(values[:10]) * 0.5
+        # Parse once: reuse for the numeric-type heuristic, sort key, and min/max.
+        # Unparseable values (e.g. "-" sentinels) sort last so useful entries are visible.
+        parsed_values: list[tuple[str, float | None]] = (
+            [(v, parser(v)) for v in values] if parser else [(v, None) for v in values]
+        )
+
+        if parser and parsed_values:
+            sampled = parsed_values[:10]
+            numeric_count = sum(1 for _, pv in sampled if pv is not None)
+            is_numeric = numeric_count >= len(sampled) * 0.5
+
+        parsed_values.sort(key=lambda pair: (pair[1] is None, pair[1] if pair[1] is not None else pair[0]))
+        sorted_values = [v for v, _ in parsed_values]
 
         attr_info: dict[str, Any] = {
             "name": name,
@@ -143,11 +155,17 @@ def list_attributes(
         }
 
         if is_numeric:
-            # For numeric, show example values
-            attr_info["example_values"] = values[:5]
+            attr_info["example_values"] = sorted_values[:5]
+            attr_info["values"] = sorted_values[:_VALUE_LIMIT]
+            parsed_floats = [pv for _, pv in parsed_values if pv is not None]
+            if parsed_floats:
+                attr_info["min"] = min(parsed_floats)
+                attr_info["max"] = max(parsed_floats)
         else:
-            # For string, show all distinct values (up to limit)
-            attr_info["values"] = sorted(values)[:20]
+            attr_info["values"] = sorted_values[:_VALUE_LIMIT]
+
+        if len(values) > _VALUE_LIMIT:
+            attr_info["total_unique"] = len(values)
 
         attributes.append(attr_info)
 

--- a/src/pcbparts_mcp/parsers.py
+++ b/src/pcbparts_mcp/parsers.py
@@ -383,6 +383,30 @@ def parse_length_mm(s: str) -> float | None:
     return float(match.group(1)) if match else None
 
 
+# Matches canned-aluminum / electrolytic dimension encoding in package strings:
+# "SMD,D6.3xL5.7mm", "D10xL10.2mm", "D8 x L12.5mm". Group 1 = diameter, group 2 = height/length.
+_PACKAGE_DIMENSIONS_PATTERN = re.compile(
+    r"D\s*(\d+(?:\.\d+)?)\s*[x×X]\s*L?\s*(\d+(?:\.\d+)?)\s*mm",
+    re.IGNORECASE,
+)
+
+
+def parse_dimensions_from_package(pkg: str) -> tuple[float | None, float | None]:
+    """Extract (diameter_mm, height_mm) from a package string.
+
+    JLCPCB often leaves the Height/Diameter spec fields as "-" for canned aluminum
+    electrolytics and similar through-hole-style SMD parts, but the package column
+    encodes the same info (e.g. "SMD,D6.3xL5.7mm"). This fallback recovers those
+    dimensions so size-based filters don't silently exclude otherwise valid parts.
+    """
+    if not pkg:
+        return None, None
+    match = _PACKAGE_DIMENSIONS_PATTERN.search(pkg)
+    if not match:
+        return None, None
+    return float(match.group(1)), float(match.group(2))
+
+
 def parse_integer(s: str) -> int | None:
     """Parse integer: '8' -> 8, '16bit' -> 16"""
     if not s:

--- a/src/pcbparts_mcp/search/engine.py
+++ b/src/pcbparts_mcp/search/engine.py
@@ -5,7 +5,8 @@ import sqlite3
 from typing import Any, Literal
 
 from ..config import DEFAULT_MIN_STOCK
-from ..alternatives import SPEC_PARSERS
+from ..alternatives import SPEC_PARSERS, DIMENSION_SPEC_FIELDS
+from ..parsers import parse_dimensions_from_package
 from ..subcategory_aliases import (
     resolve_subcategory_name as _resolve_subcategory_name,
     find_similar_subcategories as _find_similar_subcategories,
@@ -301,6 +302,12 @@ class SearchEngine:
                                 part_value = parser(attr_value)
                                 if part_value is not None:
                                     break
+
+                        if part_value is None and spec_filter.name in DIMENSION_SPEC_FIELDS:
+                            # Recover from package string when the spec field is "-" (null);
+                            # ~70% of null-height aluminum electrolytics encode dims here.
+                            diameter_mm, height_mm = parse_dimensions_from_package(part.get("package") or "")
+                            part_value = diameter_mm if spec_filter.name == "Diameter" else height_mm
 
                         if part_value is None:
                             passes = False

--- a/src/pcbparts_mcp/server.py
+++ b/src/pcbparts_mcp/server.py
@@ -435,6 +435,10 @@ async def jlc_search(
             - op: Operator: "=", ">=", "<=", ">", "<"
             - value: Value with units (e.g., "2.5V", "10uF", "20mΩ")
             Example: [{"name": "Vgs(th)", "op": "<", "value": "2.5V"}]
+            Note: range ops (<, <=, >, >=) only work on fields with a registered
+            numeric parser — call jlc_search_help(subcategory=...) and use fields
+            typed "numeric". Parts whose spec value is "-" (null) are excluded
+            from dimension filters.
 
         min_stock: Minimum stock (default 10). Database only indexes stock >= 10.
         library_type: "basic", "preferred", "no_fee", "extended", or None (all)

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -156,7 +156,7 @@ class TestSpecFilters:
 
     def test_height_le_filter_excludes_taller(self):
         """Height filter '<= 5.4mm' must not return parts taller than 5.4mm."""
-        from pcbparts_mcp.parsers import parse_length_mm
+        from pcbparts_mcp.parsers import parse_length_mm, parse_dimensions_from_package
 
         db = get_db()
         result = db.search(
@@ -170,13 +170,15 @@ class TestSpecFilters:
         for part in result["results"]:
             height = part.get("specs", {}).get("Height - Seated (Max)")
             parsed = parse_length_mm(height) if height else None
+            if parsed is None:
+                _, parsed = parse_dimensions_from_package(part.get("package") or "")
             assert parsed is not None and parsed <= 5.4 + 1e-6, (
-                f"Part {part['lcsc']} leaked with Height={height!r}"
+                f"Part {part['lcsc']} leaked with Height={height!r} pkg={part.get('package')!r}"
             )
 
     def test_diameter_ge_filter_excludes_smaller(self):
         """Diameter filter '>= 10mm' must not return parts under 10mm."""
-        from pcbparts_mcp.parsers import parse_length_mm
+        from pcbparts_mcp.parsers import parse_length_mm, parse_dimensions_from_package
 
         db = get_db()
         result = db.search(
@@ -190,13 +192,19 @@ class TestSpecFilters:
         for part in result["results"]:
             diameter = part.get("specs", {}).get("Diameter")
             parsed = parse_length_mm(diameter) if diameter else None
+            if parsed is None:
+                parsed, _ = parse_dimensions_from_package(part.get("package") or "")
             assert parsed is not None and parsed >= 10.0 - 1e-6, (
-                f"Part {part['lcsc']} leaked with Diameter={diameter!r}"
+                f"Part {part['lcsc']} leaked with Diameter={diameter!r} pkg={part.get('package')!r}"
             )
 
     def test_height_and_diameter_combined(self):
         """Combined Height/Diameter/Capacitance/Voltage filters must AND correctly."""
-        from pcbparts_mcp.parsers import parse_length_mm, parse_capacitance
+        from pcbparts_mcp.parsers import (
+            parse_length_mm,
+            parse_capacitance,
+            parse_dimensions_from_package,
+        )
 
         db = get_db()
         result = db.search(
@@ -214,10 +222,52 @@ class TestSpecFilters:
         for part in result["results"]:
             h = parse_length_mm(part["specs"].get("Height - Seated (Max)", ""))
             d = parse_length_mm(part["specs"].get("Diameter", ""))
+            if h is None or d is None:
+                pkg_d, pkg_h = parse_dimensions_from_package(part.get("package") or "")
+                h = h if h is not None else pkg_h
+                d = d if d is not None else pkg_d
             c = parse_capacitance(part["specs"].get("Capacitance", ""))
             assert h is not None and h <= 5.4 + 1e-6, f"{part['lcsc']}: height {h}"
             assert d is not None and d <= 6.3 + 1e-6, f"{part['lcsc']}: diameter {d}"
             assert c is not None and c >= 220e-6 * (1 - 1e-6), f"{part['lcsc']}: capacitance {c}"
+
+    def test_height_rescued_from_package_string(self):
+        """Null Height ('-') is rescued from a package string like 'SMD,D6.3xL5.8mm'."""
+        db = get_db()
+        result = db.search(
+            subcategory_id=2965,
+            package="SMD,D6.3xL5.8mm",
+            spec_filters=[SpecFilter("Height - Seated (Max)", "<=", "6mm")],
+            limit=50,
+            min_stock=0,
+        )
+
+        assert "error" not in result
+        lcscs = {p["lcsc"] for p in result["results"]}
+        assert "C729678" in lcscs, (
+            "C729678 (Height='-', package='SMD,D6.3xL5.8mm') should be rescued "
+            "by the package-string fallback"
+        )
+        rescued = [p for p in result["results"] if p["specs"].get("Height - Seated (Max)") == "-"]
+        assert rescued, "expected at least one null-spec part rescued via package"
+
+    def test_null_height_not_rescued_when_package_lacks_dims(self):
+        """Parts with null Height AND bare 'SMD' package (no dims) are still dropped."""
+        db = get_db()
+        result = db.search(
+            subcategory_id=2965,
+            package="SMD",
+            spec_filters=[SpecFilter("Height - Seated (Max)", "<=", "100mm")],
+            limit=100,
+            min_stock=0,
+        )
+
+        assert "error" not in result
+        lcscs = {p["lcsc"] for p in result["results"]}
+        assert "C18214363" not in lcscs, (
+            "C18214363 (Height='-', package='SMD') has no recoverable dims "
+            "and must be dropped"
+        )
 
     def test_multiple_interface_values_use_or_logic(self):
         """Multiple Interface filters should match components with EITHER value (OR logic)."""

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1032,6 +1032,44 @@ class TestListAttributes:
 
         assert "error" in result
 
+    def test_list_attributes_numeric_sort_for_height(self):
+        """Numeric-typed Height values must be sorted numerically, not lexicographically."""
+        from pcbparts_mcp.parsers import parse_length_mm
+
+        db = get_db()
+        result = db.list_attributes(subcategory_id=2965)
+        height = next(
+            (a for a in result["attributes"] if a["name"] == "Height - Seated (Max)"),
+            None,
+        )
+        assert height is not None, "Height attribute should be present in subcat 2965"
+        assert height["type"] == "numeric"
+
+        values = height["values"]
+        assert values, "Height values should not be empty"
+        first_parsed = parse_length_mm(values[0])
+        assert first_parsed is not None and first_parsed < 10.0, (
+            f"first value should be under 10mm, got {values[0]!r}"
+        )
+        if "-" in values:
+            assert values.index("-") > 0
+
+    def test_list_attributes_numeric_min_max(self):
+        """Numeric attributes should expose min/max from parsed floats."""
+        db = get_db()
+        result = db.list_attributes(subcategory_id=2965)
+        height = next(
+            (a for a in result["attributes"] if a["name"] == "Height - Seated (Max)"),
+            None,
+        )
+        assert height is not None
+        assert "min" in height and "max" in height
+        assert isinstance(height["min"], (int, float))
+        assert isinstance(height["max"], (int, float))
+        assert height["min"] < height["max"]
+        assert 2.0 <= height["min"] <= 6.0
+        assert 15.0 <= height["max"] <= 40.0
+
     def test_list_capacitor_attributes(self):
         """List attributes for MLCC capacitors."""
         db = get_db()

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -154,6 +154,71 @@ class TestSpecFilters:
         # May have fewer results with multiple filters
         assert result["total"] >= 0
 
+    def test_height_le_filter_excludes_taller(self):
+        """Height filter '<= 5.4mm' must not return parts taller than 5.4mm."""
+        from pcbparts_mcp.parsers import parse_length_mm
+
+        db = get_db()
+        result = db.search(
+            subcategory_id=2965,
+            spec_filters=[SpecFilter("Height - Seated (Max)", "<=", "5.4mm")],
+            limit=25,
+        )
+
+        assert "error" not in result
+        assert len(result["results"]) > 0, "should find at least one <=5.4mm part"
+        for part in result["results"]:
+            height = part.get("specs", {}).get("Height - Seated (Max)")
+            parsed = parse_length_mm(height) if height else None
+            assert parsed is not None and parsed <= 5.4 + 1e-6, (
+                f"Part {part['lcsc']} leaked with Height={height!r}"
+            )
+
+    def test_diameter_ge_filter_excludes_smaller(self):
+        """Diameter filter '>= 10mm' must not return parts under 10mm."""
+        from pcbparts_mcp.parsers import parse_length_mm
+
+        db = get_db()
+        result = db.search(
+            subcategory_id=2965,
+            spec_filters=[SpecFilter("Diameter", ">=", "10mm")],
+            limit=25,
+        )
+
+        assert "error" not in result
+        assert len(result["results"]) > 0
+        for part in result["results"]:
+            diameter = part.get("specs", {}).get("Diameter")
+            parsed = parse_length_mm(diameter) if diameter else None
+            assert parsed is not None and parsed >= 10.0 - 1e-6, (
+                f"Part {part['lcsc']} leaked with Diameter={diameter!r}"
+            )
+
+    def test_height_and_diameter_combined(self):
+        """Combined Height/Diameter/Capacitance/Voltage filters must AND correctly."""
+        from pcbparts_mcp.parsers import parse_length_mm, parse_capacitance
+
+        db = get_db()
+        result = db.search(
+            subcategory_id=2965,
+            spec_filters=[
+                SpecFilter("Height - Seated (Max)", "<=", "5.4mm"),
+                SpecFilter("Diameter", "<=", "6.3mm"),
+                SpecFilter("Capacitance", ">=", "220uF"),
+                SpecFilter("Voltage", ">=", "16V"),
+            ],
+            limit=25,
+        )
+
+        assert "error" not in result
+        for part in result["results"]:
+            h = parse_length_mm(part["specs"].get("Height - Seated (Max)", ""))
+            d = parse_length_mm(part["specs"].get("Diameter", ""))
+            c = parse_capacitance(part["specs"].get("Capacitance", ""))
+            assert h is not None and h <= 5.4 + 1e-6, f"{part['lcsc']}: height {h}"
+            assert d is not None and d <= 6.3 + 1e-6, f"{part['lcsc']}: diameter {d}"
+            assert c is not None and c >= 220e-6 * (1 - 1e-6), f"{part['lcsc']}: capacitance {c}"
+
     def test_multiple_interface_values_use_or_logic(self):
         """Multiple Interface filters should match components with EITHER value (OR logic)."""
         from pcbparts_mcp.smart_parser import parse_smart_query

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -12,6 +12,7 @@ from pcbparts_mcp.parsers import (
     parse_inductance,
     parse_frequency,
     parse_length_mm,
+    parse_dimensions_from_package,
     parse_memory_size,
 )
 
@@ -201,6 +202,27 @@ class TestParseLengthMm:
     def test_null_sentinels_return_none(self, input_val: str):
         """JLC uses '-' for null; other non-length strings must not coerce to a number."""
         assert parse_length_mm(input_val) is None
+
+
+class TestParseDimensionsFromPackage:
+    """Tests for parse_dimensions_from_package — canned-cap D×L encoding."""
+
+    @pytest.mark.parametrize("pkg,expected", [
+        ("SMD,D6.3xL5.7mm", (6.3, 5.7)),
+        ("SMD,D10xL10.2mm", (10.0, 10.2)),
+        ("D8xL12.5mm", (8.0, 12.5)),
+        ("SMD, D5 x L5.4 mm", (5.0, 5.4)),
+        ("D6.3×L7.7mm", (6.3, 7.7)),
+        ("SMD,d6.3xl5.8MM", (6.3, 5.8)),
+    ])
+    def test_dim_extraction(self, pkg: str, expected: tuple[float, float]):
+        got = parse_dimensions_from_package(pkg)
+        assert got[0] == pytest.approx(expected[0])
+        assert got[1] == pytest.approx(expected[1])
+
+    @pytest.mark.parametrize("pkg", ["SMD", "", "TO-220", "0805", "SOT-23-3", "radial"])
+    def test_no_dims_returns_none_pair(self, pkg: str):
+        assert parse_dimensions_from_package(pkg) == (None, None)
 
 
 class TestParseMemorySize:

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -11,6 +11,7 @@ from pcbparts_mcp.parsers import (
     parse_power,
     parse_inductance,
     parse_frequency,
+    parse_length_mm,
     parse_memory_size,
 )
 
@@ -180,6 +181,26 @@ class TestParsePower:
         """Test power parsing in watts."""
         result = parse_power(input_val)
         assert result == pytest.approx(expected), f"{input_val} should parse to {expected}"
+
+
+class TestParseLengthMm:
+    """Tests for parse_length_mm — used for Height/Diameter filters."""
+
+    @pytest.mark.parametrize("input_val,expected", [
+        ("5.4mm", 5.4),
+        ("4mm", 4.0),
+        ("10.2mm", 10.2),
+        ("21.5mm", 21.5),
+        ("6.3 mm", 6.3),
+        ("5.4MM", 5.4),
+    ])
+    def test_length_parsing(self, input_val: str, expected: float):
+        assert parse_length_mm(input_val) == pytest.approx(expected)
+
+    @pytest.mark.parametrize("input_val", ["-", "", "SMD", "N/A", "unknown"])
+    def test_null_sentinels_return_none(self, input_val: str):
+        """JLC uses '-' for null; other non-length strings must not coerce to a number."""
+        assert parse_length_mm(input_val) is None
 
 
 class TestParseMemorySize:

--- a/uv.lock
+++ b/uv.lock
@@ -772,7 +772,7 @@ wheels = [
 
 [[package]]
 name = "pcbparts-mcp"
-version = "0.5.0"
+version = "0.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
Fixes three filter bugs in `jlc_search` / `jlc_search_help` documented in #3. Four commits, each independently testable:

1. **`698d306`** — Register `parse_length_mm` in `SPEC_PARSERS` for `Height - Seated (Max)`, `Height`, `Diameter`. Fixes the case where range ops (`<=`, `>=`, `<`, `>`) on those fields were silently dropped by the query builder because the fields lacked a numeric parser.
2. **`eee3b6f`** — Add `parse_dimensions_from_package` and wire it as a post-filter fallback in `SearchEngine`. When a part's spec Height/Diameter is `"-"` (null), recover the value from the package string (e.g. `"SMD,D6.3xL5.7mm"`) before rejecting the row. Rescues ~70% of null-dimension aluminum electrolytics.
3. **`6c73cce`** — Rewrite the value-sort block in `db/attributes.py`: sort numerically when a parser is available, raise the per-field cap 20 → 50, expose `min`/`max` for numeric attributes, and add `total_unique` when the distinct count exceeds the cap. Also tighten the parser-lookup guard (`callable(parser)` instead of truthy check) so `"special"` string markers don't leak into the call path.
4. **`89f3d92`** — Document the range-op-requires-numeric-parser contract on the `jlc_search` tool docstring; bump `pyproject.toml` to `0.4.6`.

## Repro

Before the PR, on the current HEAD of `main`:

```python
jlc_search(
    subcategory_id=2965,
    spec_filters=[
        {"name": "Height - Seated (Max)", "op": "<=", "value": "5.4mm"},
        {"name": "Diameter",              "op": "<=", "value": "6.3mm"},
        {"name": "Capacitance",           "op": ">=", "value": "220uF"},
        {"name": "Voltage",               "op": ">=", "value": "16V"},
    ],
    limit=20, min_stock=3000,
)
# returns heights 7.7mm/10mm/10.2mm/10.5mm/13.5mm, diameters 6.3-12.5mm
```

After the PR:

```
distinct_heights_in_results=['5.4mm']
distinct_diameters_in_results=['6.3mm']
rows_with_height_over_5.4mm=0
```

`jlc_search_help(subcategory=2965)` Height enum before:

```
['-','10.2mm','10.3mm','10.5mm','10.8mm','10mm','11mm','12.5mm','12mm','13.5mm',
 '13mm','14.1mm','14.5mm','14mm','16.5mm','16mm','17.5mm','17mm','20.5mm','21.5mm']
```

After:

```
['3.9mm','4.5mm','5.2mm','5.3mm','5.4mm','5.5mm','5.65mm','5.7mm','5.8mm','6mm',
 '6.1mm','6.2mm','6.5mm','6.9mm','7mm','7.7mm','7.9mm','8mm','8.3mm','8.4mm',
 '8.7mm','9mm','10mm','10.2mm','10.3mm','10.5mm','10.8mm','11mm','12mm','12.5mm',
 '13mm','13.5mm','14mm','14.1mm','14.5mm','16mm','16.5mm','17mm','17.5mm','20.5mm',
 '21mm','21.5mm','22mm','25mm','-']
+ min=3.9, max=25.0
```

## Tests

16 new test cases across `tests/test_db.py` and `tests/test_parsers.py` covering parser behavior, filter correctness, the package-string fallback (positive + negative), numeric sort, and min/max surfacing. Full suite: 978 passing, 65 deselected (integration).

```
.venv/bin/pytest tests/ -v
```

## Notes

- All fixes are backward compatible. The `list_attributes` response adds new keys (`min`, `max`, `total_unique`) and raises the value cap; existing keys/semantics preserved.
- The package-string fallback only activates when both (a) the spec value is unparseable and (b) the filter's field is in `DIMENSION_SPEC_FIELDS`. For all other fields, behavior is unchanged.
- `pyproject.toml` bumped to `0.4.6` per the project convention.